### PR TITLE
Default encoding to utf-8 when "None" is found

### DIFF
--- a/rainbow_logging_handler/__init__.py
+++ b/rainbow_logging_handler/__init__.py
@@ -210,6 +210,9 @@ class RainbowLoggingHandler(logging.StreamHandler):
         import sys
         if (2, 6, 0) <= sys.version_info < (3, 0, 0) and unicode and isinstance(msg, unicode):
             enc = getattr(self.stream, 'encoding', 'utf-8')
+            if enc is None:
+                # An encoding property was found, but it was None
+                enc = 'utf-8'
             return msg.encode(enc, 'replace')
         return msg
 


### PR DESCRIPTION
It would appear that if the encoding property is set on self.stream, but
it is set to None, then we get msg.encode(None, 'replace') which causes
an error to be printed by the logging framework.
