### PR TITLE
Support for PyCharm's console

### DIFF
--- a/rainbow_logging_handler/__init__.py
+++ b/rainbow_logging_handler/__init__.py
@@ -63,6 +63,7 @@ class RainbowLoggingHandler(logging.StreamHandler):
         self, stream,
 
         datefmt='%H:%M:%S',
+        passthrough=False,
 
         color_name             = ('white' , None, True),
         color_levelno          = ('white' , None, False),
@@ -92,6 +93,8 @@ class RainbowLoggingHandler(logging.StreamHandler):
         :type color_*:  str compatible to `time.strftime()` argument
         :param datefmt: format of %(asctime)s, passed to `logging.Formatter.__init__()`.
             If `None` is passed, `logging`'s default format of '%H:%M:%S,<milliseconds>' is used.
+        :param passthrough: don't check if the handler's stream is a terminal,
+            useful for compatibility with PyCharm
         :type color_*:  `(<symbolic name of foreground color>, <symbolic name of background color>, <brightness flag>)`
         :param color_*: Each column's color. See `logging.Formatter` for supported column (`*`)
         """
@@ -99,6 +102,9 @@ class RainbowLoggingHandler(logging.StreamHandler):
 
         # set timestamp format
         self._datefmt = datefmt
+
+        # set if we should ignore stream's is_tty check
+        self._passthrough = passthrough
 
         # set custom color
         self._column_color['%(name)s']            = color_name
@@ -180,7 +186,7 @@ class RainbowLoggingHandler(logging.StreamHandler):
 
         Takes a custom formatting path on a terminal.
         """
-        if self.is_tty:
+        if self._passthrough or self.is_tty:
             message = self.colorize(record)
         else:
             message = logging.StreamHandler.format(self, record)


### PR DESCRIPTION
When using PyCharm's console the output is not colorized, this is because [PyCharm uses redirected streams](https://youtrack.jetbrains.com/issue/IDEA-132822#comment=27-853753) and as a result `self.is_tty` is always false, forzing the use of `StreamHandler.format(self, record)` instead of `self.colorize(record)`, even though PyCharms supports ANSI codes fine.

As far as I know, there isn't a way to automatically detect if a stream supports ANSI codes, so I added the flag `passthrough` to be able to ignore `self.is_tty` check.