### PR TITLE
Bugfix: datefmt on setFormatter

### DIFF
--- a/rainbow_logging_handler/__init__.py
+++ b/rainbow_logging_handler/__init__.py
@@ -203,6 +203,7 @@ class RainbowLoggingHandler(logging.StreamHandler):
         # HACK: peeping format string passed by user to `logging.Formatter()`
         if formatter._fmt:
             self._fmt = formatter._fmt
+            self._datefmt = formatter.datefmt
         logging.StreamHandler.setFormatter(self, formatter)
 
     def _encode(self, msg):


### PR DESCRIPTION
Repro:
```
>>> from rainbow_logging_handler import *
>>> DATE_FORMAT_STRING = '%m/%d/%Y %I:%M:%S %p'
>>> from logging import *
>>> f = Formatter('[%(asctime)s] %(name)s %(funcName)s():%(lineno)d\t%(message)s', datefmt=DATE_FORMAT_STRING)
>>> h = RainbowLoggingHandler(sys.stdout)
>>> h.setFormatter(f)
>>> l.addHandler(h)
>>> l.info('no date!')
[12:45:50] root <module>():1    no date!
```