### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ rainbow_logging_handler
 .. image:: https://travis-ci.org/laysakura/rainbow_logging_handler.png?branch=master
    :target: https://travis-ci.org/laysakura/rainbow_logging_handler
 
-.. image:: https://pypip.in/v/rainbow_logging_handler/badge.png
+.. image:: https://img.shields.io/pypi/v/rainbow_logging_handler.svg
     :target: https://pypi.python.org/pypi/rainbow_logging_handler
     :alt: Latest PyPI version
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20rainbow-logging-handler))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `rainbow-logging-handler`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.