### PR TITLE
deps: drop `logutils` from `setup.py` gone in 2013

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ setup(
     author           = 'Mikko Ohtamaa, Sho Nakatani',
     author_email     = 'mikko@opensourcehacker.com, lay.sakura@gmail.com',
     install_requires = [
-        'logutils',
         'colorama',
     ],
     tests_require    = [


### PR DESCRIPTION
Reliance on `logutils.ColorizingStreamHandler` had been dropped in 585f300 from 2013, but the package-requirement was never dropped.